### PR TITLE
Fixed the shell script error because of which Varity programs were failing in dev branch

### DIFF
--- a/benchmarks/Varity/Varity-intel/run.sh
+++ b/benchmarks/Varity/Varity-intel/run.sh
@@ -29,7 +29,7 @@ echo $result >> runlog.txt
 
 #err=`echo "scale=11; ($result-$ans)/$ans" | bc -q`
 if [ "$ans" == "$result" -a "$ans" != "" ]; then
-  false ## false=1 success
+  exit 0 ##  success
 else
-  true ## true=0 failed
+  exit 3 ##  failed
 fi


### PR DESCRIPTION
- The `search.py` file expects `exit 0` status if the transformation is successful and `exit 3` if the transformation results are inconsistent from the `run.sh` file in `dev` branch. But in master branch the `search.py` was expecting either `success` or `failed` string which resulted in Varity programs not working in dev branch.